### PR TITLE
增加 rune 的說明

### DIFF
--- a/lib/string/string.go
+++ b/lib/string/string.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"unicode/utf8"
 )
 
 //PadLeft 左邊補齊
@@ -62,4 +63,22 @@ func LengthOfLongestSubstring(s string) int {
 		//fmt.Println("start =", start)
 	}
 	return length
+}
+
+//GoRUNS 解析 rune 型態
+func GoRUNS() {
+	var str = "hello, 你好嗎?"
+	//golang中string底層是用byte實作的，len 實際是在用字元長度計算大小 所以一中文占3個字元長度,大小就是12了
+	fmt.Println("len(str):", len(str))
+
+	//以下2種方法都可以得到str的字串的長度
+
+	//golang中的unicode/utf8包提供了用utf-8獲取長度的方法
+	fmt.Println("RuneCountInString:", utf8.RuneCountInString(str))
+
+	//用rune型態來unicode字串
+	fmt.Println("rune:", len([]rune(str)))
+
+	//byte 等於int8， 大致用来處理ascii字元
+	//rune 等於int32, 大致用来處理unicode或utf-8字串
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 
 }
 
+//findMedianSortedArrays 尋找中位數
 func findMedianSortedArrays(nums1 []int, nums2 []int) float64 {
 	i, j := 0, 0
 	nums3 := []int{}


### PR DESCRIPTION
```
golang中string底层是通过byte数组实现的。中文字符在unicode下占2个字节，在utf-8编码下占3个字节，而golang默认编码正好是utf-8。
```

* byte 等同于int8，用来处理ascii字符
* rune 等同于int32, 用来处理unicode或utf-8字符